### PR TITLE
Update to 2023.4.12142.20230526T152858Z-230200

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
   <groupId>io.wcm.maven</groupId>
   <artifactId>io.wcm.maven.aem-cloud-dependencies</artifactId>
-  <version>2023.5.11983.20230511T173830Z-230200.0001-SNAPSHOT</version>
+  <version>2023.4.12142.20230526T152858Z-230200.0000-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>AEM Cloud Service Dependencies</name>
@@ -86,7 +86,7 @@
         <groupId>com.adobe.aem</groupId>
         <artifactId>aem-sdk-api</artifactId>
         <!-- update-aem-deps:from-aem-sdk-api -->
-        <version>2023.5.11983.20230511T173830Z-230200</version>
+        <version>2023.4.12142.20230526T152858Z-230200</version>
       </dependency>
 
       <!-- OSGI (individual artifacts) -->
@@ -313,13 +313,13 @@
       <dependency>
         <groupId>com.adobe.cq</groupId>
         <artifactId>core.wcm.components.core</artifactId>
-        <version>2.22.10</version>
+        <version>2.22.12</version>
       </dependency>
       <dependency>
         <groupId>com.adobe.cq</groupId>
         <artifactId>core.wcm.components.testing.aem-mock-plugin</artifactId>
         <!-- update-aem-deps:bundle=com.adobe.cq.core.wcm.components.core -->
-        <version>2.22.10</version>
+        <version>2.22.12</version>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>


### PR DESCRIPTION
strange: although it is a new AEMaaCS release 12142, the "marketing" version number was _decreased_ from 5 to 4 - this will puzzle all version-based tooling like maven in a way, that this new version is not detected as new version.

so i'm tending to skip this release and wait for the next one, assuming this problem will be detected and fixed soon.