### PR TITLE
Update to 2024.4.15787.20240404T134829Z-231200

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
   <groupId>io.wcm.maven</groupId>
   <artifactId>io.wcm.maven.aem-cloud-dependencies</artifactId>
-  <version>2024.3.15575.20240318T214814Z-231200.0001-SNAPSHOT</version>
+  <version>2024.4.15787.20240404T134829Z-231200.0000-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>AEM Cloud Service Dependencies</name>
@@ -86,7 +86,7 @@
         <groupId>com.adobe.aem</groupId>
         <artifactId>aem-sdk-api</artifactId>
         <!-- update-aem-deps:from-aem-sdk-api -->
-        <version>2024.3.15575.20240318T214814Z-231200</version>
+        <version>2024.4.15787.20240404T134829Z-231200</version>
       </dependency>
 
       <!-- OSGI (individual artifacts) -->
@@ -313,13 +313,13 @@
       <dependency>
         <groupId>com.adobe.cq</groupId>
         <artifactId>core.wcm.components.core</artifactId>
-        <version>2.23.4</version>
+        <version>2.24.2</version>
       </dependency>
       <dependency>
         <groupId>com.adobe.cq</groupId>
         <artifactId>core.wcm.components.testing.aem-mock-plugin</artifactId>
         <!-- update-aem-deps:bundle=com.adobe.cq.core.wcm.components.core -->
-        <version>2.23.4</version>
+        <version>2.24.2</version>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>
@@ -518,19 +518,19 @@
       <dependency>
         <groupId>org.apache.sling</groupId>
         <artifactId>org.apache.sling.commons.johnzon</artifactId>
-        <version>1.2.16</version>
+        <version>2.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.johnzon</groupId>
         <artifactId>johnzon-core</artifactId>
-        <!-- update-aem-deps:derived-from=org.apache.sling.commons.johnzon:1.2.16 -->
-        <version>1.2.21</version>
+        <!-- update-aem-deps:derived-from=org.apache.sling.commons.johnzon:2.0.0 -->
+        <version>2.0.0</version>
       </dependency>
       <dependency>
-        <groupId>org.apache.geronimo.specs</groupId>
-        <artifactId>geronimo-json_1.1_spec</artifactId>
-        <!-- update-aem-deps:derived-from=org.apache.sling.commons.johnzon:1.2.16 -->
-        <version>1.3</version>
+        <groupId>jakarta.json</groupId>
+        <artifactId>jakarta.json-api</artifactId>
+        <!-- update-aem-deps:derived-from=org.apache.sling.commons.johnzon:2.0.0 -->
+        <version>2.1.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.sling</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -532,6 +532,13 @@
         <!-- update-aem-deps:derived-from=org.apache.sling.commons.johnzon:2.0.0 -->
         <version>2.1.1</version>
       </dependency>
+      <!-- Update to latest Sling JSON Content Parser 2.x for unit tests for compatibility with Johnzon 2.0 (switch from javax.json to jakarta.json) -->
+      <dependency>
+        <groupId>org.apache.sling</groupId>
+        <artifactId>org.apache.sling.contentparser.json</artifactId>
+        <!-- update-aem-deps:ignore -->
+        <version>2.1.0-SNAPSHOT</version>
+      </dependency>
       <dependency>
         <groupId>org.apache.sling</groupId>
         <artifactId>org.apache.sling.commons.json</artifactId>


### PR DESCRIPTION
currently blocked by https://issues.apache.org/jira/browse/SLING-12280 (and related release) as a solution for the switch to johnzon 2.0 / switch from javax.json to jakarta.json