### PR TITLE
Switch to JSONP 2.1 (jakarta.json) and Johnzon 2.0 by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ To import the dependencies in your AEM project use:
 </dependency>
 ```
 
+*Please note*: Since version `2024.6.16971.20240628T122619Z-240600.0001` JSONP 2.1 and Johnzon 2.x is used by default by this POM. If your code, or dependencies of your project, still rely on JSONP 1.1 and Johnzon 1.2.x, you can use the [Mixin for JSONP 1.1](https://github.com/wcm-io/io.wcm.maven.aem-cloud-dependencies-mixin-jsonp11).
+
+
 
 ## Release cycle
 

--- a/pom.xml
+++ b/pom.xml
@@ -529,15 +529,21 @@
       <dependency>
         <groupId>org.apache.johnzon</groupId>
         <artifactId>johnzon-core</artifactId>
-        <!-- Stick with Johnzon 1.x as long as other modules (esp. Adobe Core Components) still depend on javax.json -->
-        <!-- update-aem-deps:derived-from=com.adobe.granite.commons.johnzon:1.2.16 -->
-        <version>1.2.21</version>
+        <!-- update-aem-deps:derived-from=org.apache.sling.commons.johnzon:2.0.0 -->
+        <version>2.0.0</version>
       </dependency>
       <dependency>
-        <groupId>org.apache.geronimo.specs</groupId>
-        <artifactId>geronimo-json_1.1_spec</artifactId>
-        <!-- update-aem-deps:derived-from=com.adobe.granite.commons.johnzon:1.2.16 -->
-        <version>1.3</version>
+        <groupId>jakarta.json</groupId>
+        <artifactId>jakarta.json-api</artifactId>
+        <!-- update-aem-deps:derived-from=org.apache.sling.commons.johnzon:2.0.0 -->
+        <version>2.1.1</version>
+      </dependency>
+      <!-- Update to latest Sling JSON Content Parser 2.x for unit tests for compatibility with Johnzon 2.0 (switch from javax.json to jakarta.json) -->
+      <dependency>
+        <groupId>org.apache.sling</groupId>
+        <artifactId>org.apache.sling.contentparser.json</artifactId>
+        <!-- update-aem-deps:ignore -->
+        <version>2.1.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.sling</groupId>


### PR DESCRIPTION
new attempt after introducing it in #52 and reverting it in #53.

this time, we additional provide a new "mixin POM", which allows projects still relying on JSONP 1.1 to downgrade only the related dependencies to older versions:
https://github.com/wcm-io/io.wcm.maven.aem-cloud-dependencies-mixin-jsonp11

Fixes #62
Fixes #60