### PR TITLE
Obtain AEMaaCS SDK version from /system/console/productinfo

### DIFF
--- a/update-aem-deps.groovy
+++ b/update-aem-deps.groovy
@@ -143,8 +143,12 @@ def readAemUrl(relativeUrl) {
 
 // reads the AEM version from locale AEM instance and finds the matching AEM SDK version in the maven repository
 def resolveAemSdkVersion() {
-  // PLEASE NOTE: this works only when a valid 'license.properties' is located beneath the quickstart JAR file
-  def aemVersion = (readAemUrl('/system/console/status-productinfo.txt') =~ /Adobe Experience Manager \((.*)\)/)[0][1]
+  def productInfoUrl = '/system/console/productinfo'
+  def aemVersionMatcher = (readAemUrl(productInfoUrl) =~ /Adobe Experience Manager \((.*)\)/)
+  if (!aemVersionMatcher) {
+    throw new RuntimeException('Adobe Experience Manager version not present in product info from ' + productInfoUrl)
+  }
+  def aemVersion = aemVersionMatcher[0][1]
 
   // need to transform from a AEM version like '2020.4.2793.20200403T195013Z' to '2020.04.2793.20200403T195013Z-200130'
   def versionPattern = Pattern.compile(aemVersion.replaceAll('\\.','.*') + '-.*')


### PR DESCRIPTION
instead of from `/system/console/status-productinfo.txt`, because the later does only work when a `license.properties` file is present. down is that we have to parse a huge HTML chunk, but it works with the same regex to extract the version.

fixes #68 