### PR TITLE
Add individual dependencies for Sling Event and Sling Commons Scheduler

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -509,6 +509,22 @@
       </dependency>
       <dependency>
         <groupId>org.apache.sling</groupId>
+        <artifactId>org.apache.sling.commons.scheduler</artifactId>
+        <version>2.7.12</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.sling</groupId>
+        <artifactId>org.apache.sling.event</artifactId>
+        <version>4.3.14</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.sling</groupId>
+        <artifactId>org.apache.sling.event.api</artifactId>
+        <!-- update-aem-deps:derived-from=org.apache.sling.event:4.3.14 -->
+        <version>1.0.4</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.sling</groupId>
         <artifactId>org.apache.sling.resourceresolver</artifactId>
         <version>1.12.8</version>
       </dependency>


### PR DESCRIPTION
to be in sync with https://github.com/wcm-io/io.wcm.maven.aem-dependencies/issues/24